### PR TITLE
Update macos.mdx: Fixed Typo

### DIFF
--- a/zh/amdl/quickstart/macos.mdx
+++ b/zh/amdl/quickstart/macos.mdx
@@ -52,7 +52,7 @@ icon: 'apple'
     You can then use the download commands to start downloading.
 
     <CodeGroup>
-      ```Go Albun/Playlist/Artist
+      ```Go Album/Playlist/Artist
       go run main.go url
       ```
 


### PR DESCRIPTION
Corrected typo: Albun -> Album